### PR TITLE
Don't delegate DropProxy#object_id

### DIFF
--- a/lib/liquor/drop.rb
+++ b/lib/liquor/drop.rb
@@ -201,7 +201,7 @@ module Liquor
 
       #
       # It is very important that we do not delegate the 'to_liquor' method and it returns 'self'.
-      NON_DELEGATE_METHODS = ['class', 'send', 'to_liquor', 'respond_to?']
+      NON_DELEGATE_METHODS = ['class', 'object_id', 'respond_to?', 'send', 'to_liquor']
       [].methods.each do |m|
         unless m =~ /^__/ || NON_DELEGATE_METHODS.include?(m.to_s)
           delegate m, :to => :proxy_found


### PR DESCRIPTION
Fixed warning on 1.9:

```
~/.rvm/gems/ruby-1.9.3-p194/gems/liquor-0.1.1/lib/liquor/drop.rb:206: warning: redefining `object_id' may cause serious problems
```
