### PR TITLE
Two more tests for find_all_by function.

### DIFF
--- a/lib/liquor/builtins.rb
+++ b/lib/liquor/builtins.rb
@@ -354,16 +354,16 @@ module Liquor
       arg.compact
     end
 
-    function "even", unnamed_arg: :integer do |arg,|
+    function "is_even", unnamed_arg: :integer do |arg,|
       (arg % 2) == 0
     end
 
-    function "odd", unnamed_arg: :integer do |arg,|
+    function "is_odd", unnamed_arg: :integer do |arg,|
       (arg % 2) == 1
     end
 
-    function "empty", unnamed_arg: :tuple do |arg,|
-      arg.empty?
+    function "is_empty", unnamed_arg: [:tuple, :external] do |arg,|
+      arg.size == 0
     end
   end
 end

--- a/lib/liquor/builtins.rb
+++ b/lib/liquor/builtins.rb
@@ -361,5 +361,9 @@ module Liquor
     function "odd", unnamed_arg: :integer do |arg,|
       (arg % 2) == 1
     end
+
+    function "empty", unnamed_arg: :tuple do |arg,|
+      arg.empty?
+    end
   end
 end

--- a/spec/builtins_spec.rb
+++ b/spec/builtins_spec.rb
@@ -174,5 +174,7 @@ describe Liquor do
     exec(%!{{ [ 1, null, 3 ] | compact | join }}!).should == "1 3"
     exec(%!{% if even(1) then: %}yes{% else: %}no{% end if %}!).should == "no"
     exec(%!{% if odd(1) then: %}yes{% else: %}no{% end if %}!).should == "yes"
+    exec(%!{% if empty([]) then: %}yes{% end if%}!).should == "yes"
+    exec(%|{% if !empty([1,2,3]) then: %}not empty{% end if %}|).should == "not empty"
   end
 end

--- a/spec/builtins_spec.rb
+++ b/spec/builtins_spec.rb
@@ -172,9 +172,9 @@ describe Liquor do
     exec(%!{% if include([ 1, 2, 3 ] element: 2) then: %}yes{% end if %}!).should == "yes"
     exec(%!{{ [ 1, 2, 3 ] | reverse | join }}!).should == "3 2 1"
     exec(%!{{ [ 1, null, 3 ] | compact | join }}!).should == "1 3"
-    exec(%!{% if even(1) then: %}yes{% else: %}no{% end if %}!).should == "no"
-    exec(%!{% if odd(1) then: %}yes{% else: %}no{% end if %}!).should == "yes"
-    exec(%!{% if empty([]) then: %}yes{% end if%}!).should == "yes"
-    exec(%|{% if !empty([1,2,3]) then: %}not empty{% end if %}|).should == "not empty"
+    exec(%!{% if is_even(1) then: %}yes{% else: %}no{% end if %}!).should == "no"
+    exec(%!{% if is_odd(1) then: %}yes{% else: %}no{% end if %}!).should == "yes"
+    exec(%!{% if is_empty([]) then: %}yes{% end if%}!).should == "yes"
+    exec(%|{% if !is_empty([1,2,3]) then: %}not empty{% end if %}|).should == "not empty"
   end
 end

--- a/spec/drop_spec.rb
+++ b/spec/drop_spec.rb
@@ -106,6 +106,20 @@ describe Liquor::Drop do
     exec(%|{{ users.find_all_by(occupation: "manager").count }}|, users: User.to_drop).should == '1'
   end
 
+  it "should provide [] access to the elements, returned by find_all_by function" do
+    exec(%|
+      {% assign found_users = users.find_all_by(occupation: "developer") %}
+      {{ found_users[0].login }}
+    |, users: User.to_drop).strip.should == 'dhh'
+  end
+
+  it "should accept scope returned by find_all_by in for statements" do
+    exec(%|
+      {% for user in: users.find_all_by(occupation: "developer") do: %}
+        {{ user.login }}
+      {% end for %}
+    |, users: User.to_drop).strip.should == "dhh\n      \n        me"
+  end
 
   it "should return intact source" do
     @dhh.to_drop.source.should == @dhh

--- a/spec/drop_spec.rb
+++ b/spec/drop_spec.rb
@@ -121,6 +121,11 @@ describe Liquor::Drop do
     |, users: User.to_drop).strip.should == "dhh\n      \n        me"
   end
 
+  it "should accept scope returned by find_all into empty() function" do
+    exec(%|{% if !is_empty(users.find_all_by(occupation: "developer")) then: %}it works{%end if%}|, users: User.to_drop).should == "it works"
+    exec(%|{% if is_empty(users.find_all_by(occupation: "idiot")) then: %}it works{% end if%}|, users: User.to_drop).should == "it works"
+  end
+
   it "should return intact source" do
     @dhh.to_drop.source.should == @dhh
   end


### PR DESCRIPTION
Added two more tests to ensure find_all_by behaves in a way suitable for plain dump php programming style. 

I found out that you can't access an element by index in the line you use find_all_by like that: 

<pre>users.find_all_by(occupation: "developer")[0]</pre>


And we might want to add an ability to use related object as a search criteria like that:

<pre>site.banners.find_all_by(banner_category: category)</pre>
